### PR TITLE
Updated Game1 example for TiledSharp

### DIFF
--- a/TiledSharp MonoGame Example/Content/exampleMap.tmx
+++ b/TiledSharp MonoGame Example/Content/exampleMap.tmx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="8" height="8" tilewidth="32" tileheight="32" nextobjectid="1">
  <tileset firstgid="1" name="exampleTileset" tilewidth="32" tileheight="32">
-  <image source="C:/Users/Teemu/Pictures/exampleTileset.png" width="64" height="64"/>
+  <image source="exampleTileset.png" width="64" height="64"/>
  </tileset>
  <layer name="Tile Layer 1" width="8" height="8">
   <data encoding="base64" compression="zlib">

--- a/TiledSharp MonoGame Example/Game1.cs
+++ b/TiledSharp MonoGame Example/Game1.cs
@@ -19,6 +19,8 @@ namespace TiledSharp_MonoGame_Example
 
         int tileWidth;
         int tileHeight;
+        int tilesetTilesWide;
+        int tilesetTilesHigh;
 
         public Game1()
         {
@@ -53,6 +55,9 @@ namespace TiledSharp_MonoGame_Example
 
             tileWidth = map.Tilesets[0].TileWidth;
             tileHeight = map.Tilesets[0].TileHeight;
+
+            tilesetTilesWide = tileset.Width / tileWidth;
+            tilesetTilesHigh = tileset.Height / tileHeight;
         }
 
         /// <summary>
@@ -96,15 +101,15 @@ namespace TiledSharp_MonoGame_Example
                 }
                 else {
                     int tileFrame = gid - 1;
-                    int column = tileFrame % (tileset.Width / tileWidth);
-                    int row = tileFrame / (tileset.Height / tileHeight);
+                    int column = tileFrame % tilesetTilesWide;
+                    int row = (tileFrame+1 > tilesetTilesWide) ? tileFrame - column * tilesetTilesWide : 0;
 
                     float x = (i % map.Width) * map.TileWidth;
                     float y = (float)Math.Floor(i / (double)map.Width) * map.TileHeight;
 
-                    Rectangle tilesetRec = new Rectangle(tileWidth * column, tileHeight * row, 32, 32);
+                    Rectangle tilesetRec = new Rectangle(tileWidth * column, tileHeight * row, tileWidth, tileHeight);
 
-                    spriteBatch.Draw(tileset, new Rectangle((int)x, (int)y, 32, 32), tilesetRec, Color.White);
+                    spriteBatch.Draw(tileset, new Rectangle((int)x, (int)y, tileWidth, tileHeight), tilesetRec, Color.White);
                 }
             }
 


### PR DESCRIPTION
I've update the Game1 example to support Tilesets of 1 tile high, and some math issues with varying size tilesets.

This version should work more universally.

I also updated the sample tmx document to use a relative path, rather than an absolute path.
